### PR TITLE
Make it work with other OS:es than Ubuntu/Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,11 @@
     repo: 'ppa:vbernat/haproxy-{{ haproxy_version }}'
     state: present
     validate_certs: no
+  when: (ansible_distribution == "Debian") or
+        (ansible_distribution == "Ubuntu")
 
 - name: install HAProxy "{{ haproxy_version }}"
-  apt:
+  package:
     name: haproxy
     state: present
   notify:


### PR DESCRIPTION
Using Package instead of APT, and using apt_repository only when on Debian or Ubuntu opens up for using this role with for example Centos